### PR TITLE
Added conda recipes

### DIFF
--- a/conda-recipe/build.sh
+++ b/conda-recipe/build.sh
@@ -1,0 +1,19 @@
+cmake . \
+    -DAQUAGPUSPH_3D=ON \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DOPENCL_ROOT_DIR=/etc/OpenCL \
+    -DPYTHON_LIBRARIES=$LIBRARY_PATH \
+    -DPYTHON_INCLUDE_DIRS=$INCLUDE_PATH \
+    -DPYTHON_LIBRARY=$LIBRARY_PATH/libpython$PY_VER.so \
+    -DPYTHON_INCLUDE_DIR=$INCLUDE_PATH/python$PY_VER \
+    -DCMAKE_INSTALL_PREFIX=$PREFIX \
+    -DCMAKE_INSTALL_RPATH=$LIBRARY_PATH \
+    -DCMAKE_PREFIX_PATH=$PREFIX \
+    -DAQUAGPUSPH_USE_VTK:BOOL=ON \
+    -DAQUAGPUSPH_USE_NCURSES:BOOL=OFF \
+    -DLLVM_LIBRARY=$LIBRARY_PATH/libLLVM-3.3.so
+
+# HACK to fix the link rpath directory
+sed -e "s;conda-bld/work/lib;envs/_build/lib;" -i $SRC_DIR/src/CMakeFiles/AQUAgpusph.dir/link.txt
+make
+make install

--- a/conda-recipe/compile.log
+++ b/conda-recipe/compile.log
@@ -1,0 +1,5 @@
+Removing old build directory
+Removing old work directory
+BUILD START: aquagpusph-2.0-np19py27_8
+Fetching package metadata: ..There was an error importing jinja2.
+Please run `conda install jinja2` to enable jinja template support

--- a/conda-recipe/fixes.patch
+++ b/conda-recipe/fixes.patch
@@ -1,0 +1,26 @@
+diff --git a/cMake/FindNumpy.cmake b/cMake/FindNumpy.cmake
+index c2a7ce0..af046d8 100644
+--- cMake/FindNumpy.cmake
++++ cMake/FindNumpy.cmake
+@@ -28,6 +28,8 @@ FIND_PATH(NUMPY_INCLUDE_DIRS
+     ${NUMPY_INCLUDE_DIR}
+ )
+ 
++INCLUDE_DIRECTORIES(${NUMPY_INCLUDE_DIR} ${NUMPY_INCLUDE_DIRS})
++
+ # Lets find the numpy module
+ EXECUTE_PROCESS(
+     COMMAND ${PYTHON_EXECUTABLE} -c "import numpy, os; print os.path.dirname(numpy.__file__)"
+diff --git a/cMake/FindOpenCL.cmake b/cMake/FindOpenCL.cmake
+index 5367495..6fba41c 100755
+--- cMake/FindOpenCL.cmake
++++ cMake/FindOpenCL.cmake
+@@ -47,7 +47,7 @@
+ INCLUDE (FindPackageHandleStandardArgs)
+ 
+ IF (CMAKE_SIZEOF_VOID_P EQUAL 8)
+-	SET (_OPENCL_POSSIBLE_LIB_SUFFIXES lib/Win64 lib/x86_64 lib/x64)
++	SET (_OPENCL_POSSIBLE_LIB_SUFFIXES lib/Win64 lib/x86_64 lib/x64 lib64/)
+ ELSE (CMAKE_SIZEOF_VOID_P EQUAL 8)
+ 	SET (_OPENCL_POSSIBLE_LIB_SUFFIXES lib/Win32 lib/x86)
+ ENDIF (CMAKE_SIZEOF_VOID_P EQUAL 8)

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,0 +1,37 @@
+package:
+  name: aquagpusph
+  version: "2.0"
+
+source:
+  git_url: https://github.com/sanguinariojoe/aquagpusph.git
+  git_tag: "2.0"
+
+  patches:
+    - fixes.patch
+
+build:
+  number: 1
+
+requirements:
+  build:
+    - python
+    - cmake
+    - numpy
+    #- xerces-c
+    - eigen3
+    #- libmatheval
+    - llvm
+    - vtk
+
+  run:
+    - python
+    - numpy
+    #- xerces-c
+    - eigen3
+    #- libmatheval
+    - llvm
+    - vtk
+
+about:
+  home: http://canal.etsin.upm.es/aquagpusph/
+  license: The GNU General Public License, version 3.0


### PR DESCRIPTION
Included patch to account for different building and installation locations. I was unable to trace where the problem in `link.txt` is but I managed to patch it at the right moment. This allows me to quickly rebuild AQUAgpusph every time I need it using `conda build conda-recipe --python 27`.
